### PR TITLE
Add additional configuration parameters to FBCache node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,7 @@
-from .fbcache_nodes import ApplyFBCacheOnModel
+from .fbcache_nodes import (
+    ApplyFBCacheOnModel,
+    ApplyFBCacheOnModelAdvanced,
+)
 from .misc_nodes import (
     EnhancedLoadDiffusionModel,
     EnhancedCompileModel,
@@ -34,6 +37,7 @@ patch_cast_to()
 
 NODE_CLASS_MAPPINGS = {
     "ApplyFBCacheOnModel": ApplyFBCacheOnModel,
+    "ApplyFBCacheOnModelAdvanced": ApplyFBCacheOnModelAdvanced,
     "EnhancedLoadDiffusionModel": EnhancedLoadDiffusionModel,
     "EnhancedCompileModel": EnhancedCompileModel,
     "VelocatorLoadAndQuantizeDiffusionModel": VelocatorLoadAndQuantizeDiffusionModel,
@@ -44,6 +48,7 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "ApplyFBCacheOnModel": "Apply First Block Cache",
+    "ApplyFBCacheOnModelAdvanced": "Apply First Block Cache (advanced)",
     "EnhancedLoadDiffusionModel": "Load Diffusion Model+",
     "EnhancedCompileModel": "Compile Model+",
     "VelocatorLoadAndQuantizeDiffusionModel": "🚀Load & Quantize Diffusion Model",

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,4 @@
-from .fbcache_nodes import (
-    ApplyFBCacheOnModel,
-    ApplyFBCacheOnModelAdvanced,
-)
+from .fbcache_nodes import ApplyFBCacheOnModel
 from .misc_nodes import (
     EnhancedLoadDiffusionModel,
     EnhancedCompileModel,
@@ -37,7 +34,6 @@ patch_cast_to()
 
 NODE_CLASS_MAPPINGS = {
     "ApplyFBCacheOnModel": ApplyFBCacheOnModel,
-    "ApplyFBCacheOnModelAdvanced": ApplyFBCacheOnModelAdvanced,
     "EnhancedLoadDiffusionModel": EnhancedLoadDiffusionModel,
     "EnhancedCompileModel": EnhancedCompileModel,
     "VelocatorLoadAndQuantizeDiffusionModel": VelocatorLoadAndQuantizeDiffusionModel,
@@ -48,7 +44,6 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "ApplyFBCacheOnModel": "Apply First Block Cache",
-    "ApplyFBCacheOnModelAdvanced": "Apply First Block Cache (advanced)",
     "EnhancedLoadDiffusionModel": "Load Diffusion Model+",
     "EnhancedCompileModel": "Compile Model+",
     "VelocatorLoadAndQuantizeDiffusionModel": "🚀Load & Quantize Diffusion Model",

--- a/fbcache_nodes.py
+++ b/fbcache_nodes.py
@@ -2,6 +2,8 @@ import contextlib
 import unittest
 import torch
 
+from comfy import model_management
+
 from . import first_block_cache
 
 
@@ -25,6 +27,7 @@ class ApplyFBCacheOnModel:
                         "min": 0.0,
                         "max": 1.0,
                         "step": 0.001,
+                        "tooltip": "Controls the tolerance for caching with lower values being more strict. Setting this to 0 disables the FBCache effect.",
                     },
                 ),
             }
@@ -40,8 +43,15 @@ class ApplyFBCacheOnModel:
         model,
         object_to_patch,
         residual_diff_threshold,
+        max_consecutive_cache_hits=None,
+        start_percent=None,
+        end_percent=None,
     ):
+        if residual_diff_threshold <= 0:
+            return (model,)
         prev_timestep = None
+        current_timestep = None
+        consecutive_cache_hits = 0
 
         model = model.clone()
         diffusion_model = model.get_model_object(object_to_patch)
@@ -60,6 +70,24 @@ class ApplyFBCacheOnModel:
         if hasattr(diffusion_model, "single_blocks"):
             single_blocks_name = "single_blocks"
 
+        if start_percent is not None or end_percent is not None:
+            model_sampling = model.get_model_object("model_sampling")
+            start_sigma, end_sigma = (
+                None if pct is None else float(model_sampling.percent_to_sigma(pct))
+                for pct in (start_percent, end_percent)
+            )
+            del model_sampling
+        else:
+            start_sigma = end_sigma = None
+
+        def validate_use_cache(use_cached):
+            nonlocal consecutive_cache_hits
+            use_cached = use_cached and (start_sigma is None or current_timestep <= start_sigma)
+            use_cached = use_cached and (end_sigma is None or current_timestep >= end_sigma)
+            use_cached = use_cached and (max_consecutive_cache_hits is None or consecutive_cache_hits < max_consecutive_cache_hits)
+            consecutive_cache_hits = consecutive_cache_hits + 1 if use_cached else 0
+            return use_cached
+
         cached_transformer_blocks = torch.nn.ModuleList([
             first_block_cache.CachedTransformerBlocks(
                 None if double_blocks_name is None else getattr(
@@ -67,6 +95,7 @@ class ApplyFBCacheOnModel:
                 None if single_blocks_name is None else getattr(
                     diffusion_model, single_blocks_name),
                 residual_diff_threshold=residual_diff_threshold,
+                validate_can_use_cache_function=validate_use_cache,
                 cat_hidden_states_first=diffusion_model.__class__.__name__ ==
                 "HunyuanVideo",
                 return_hidden_states_only=diffusion_model.__class__.__name__ ==
@@ -82,28 +111,67 @@ class ApplyFBCacheOnModel:
         dummy_single_transformer_blocks = torch.nn.ModuleList()
 
         def model_unet_function_wrapper(model_function, kwargs):
-            nonlocal prev_timestep
+            nonlocal prev_timestep, current_timestep, consecutive_cache_hits
 
-            input = kwargs["input"]
-            timestep = kwargs["timestep"]
-            c = kwargs["c"]
-            t = timestep[0].item()
+            try:
+                input = kwargs["input"]
+                timestep = kwargs["timestep"]
+                c = kwargs["c"]
+                current_timestep = t = timestep[0].item()
 
-            if prev_timestep is None or t >= prev_timestep:
-                prev_timestep = t
-                first_block_cache.set_current_cache_context(
-                    first_block_cache.create_cache_context())
+                if prev_timestep is None or t >= prev_timestep:
+                    prev_timestep = t
+                    consecutive_cache_hits = 0
+                    first_block_cache.set_current_cache_context(
+                        first_block_cache.create_cache_context())
 
-            with unittest.mock.patch.object(
-                    diffusion_model,
-                    double_blocks_name,
-                    cached_transformer_blocks,
-            ), unittest.mock.patch.object(
-                    diffusion_model,
-                    single_blocks_name,
-                    dummy_single_transformer_blocks,
-            ) if single_blocks_name is not None else contextlib.nullcontext():
-                return model_function(input, timestep, **c)
+                with unittest.mock.patch.object(
+                        diffusion_model,
+                        double_blocks_name,
+                        cached_transformer_blocks,
+                ), unittest.mock.patch.object(
+                        diffusion_model,
+                        single_blocks_name,
+                        dummy_single_transformer_blocks,
+                ) if single_blocks_name is not None else contextlib.nullcontext():
+                    return model_function(input, timestep, **c)
+            except model_management.InterruptProcessingException as exc:
+                prev_timestep = None
+                raise exc from None
 
         model.set_model_unet_function_wrapper(model_unet_function_wrapper)
         return (model, )
+
+
+class ApplyFBCacheOnModelAdvanced(ApplyFBCacheOnModel):
+    @classmethod
+    def INPUT_TYPES(cls):
+        result = super().INPUT_TYPES()
+        result["required"] |= {
+            "start_percent": (
+                "FLOAT", {
+                    "default": 0.0,
+                    "step": 0.01,
+                    "max": 1.0,
+                    "min": 0.0,
+                    "tooltip": "Start time as a percentage of sampling where the FBCache effect can apply.",
+                },
+            ),
+            "end_percent": (
+                "FLOAT", {
+                    "default": 1.0,
+                    "step": 0.01,
+                    "max": 1.0,
+                    "min": 0.0,
+                    "tooltip": "End time as a percentage of sampling where the FBCache effect can apply.",
+                }
+            ),
+            "max_consecutive_cache_hits": (
+                "INT", {
+                    "default": 2,
+                    "min": 1,
+                    "tooltip": "Allows putting a limit on how many cached results can be used in a row. For example, setting this to 1 will mean there will be at least one full model call after each cached result.",
+                },
+            ),
+        }
+        return result

--- a/fbcache_nodes.py
+++ b/fbcache_nodes.py
@@ -105,6 +105,7 @@ class ApplyFBCacheOnModel:
         else:
             start_sigma = end_sigma = None
 
+        @torch.compiler.disable()
         def validate_use_cache(use_cached):
             nonlocal consecutive_cache_hits
             use_cached = use_cached and (start_sigma is None or current_timestep <= start_sigma)

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -77,6 +77,8 @@ def cache_context(cache_context):
 
 @torch.compiler.disable()
 def are_two_tensors_similar(t1, t2, *, threshold):
+    if t1.shape != t2.shape:
+        return False
     mean_diff = (t1 - t2).abs().mean()
     mean_t1 = t1.abs().mean()
     diff = mean_diff / mean_t1

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -124,7 +124,7 @@ class CachedTransformerBlocks(torch.nn.Module):
         single_transformer_blocks=None,
         *,
         residual_diff_threshold,
-        validate_can_use_cache_function,
+        validate_can_use_cache_function=None,
         return_hidden_states_first=True,
         accept_hidden_states_first=True,
         cat_hidden_states_first=False,
@@ -135,7 +135,7 @@ class CachedTransformerBlocks(torch.nn.Module):
         self.transformer_blocks = transformer_blocks
         self.single_transformer_blocks = single_transformer_blocks
         self.residual_diff_threshold = residual_diff_threshold
-        self.validate_can_use_cache_function=validate_can_use_cache_function
+        self.validate_can_use_cache_function = validate_can_use_cache_function
         self.return_hidden_states_first = return_hidden_states_first
         self.accept_hidden_states_first = accept_hidden_states_first
         self.cat_hidden_states_first = cat_hidden_states_first
@@ -213,12 +213,12 @@ class CachedTransformerBlocks(torch.nn.Module):
         first_hidden_states_residual = hidden_states - original_hidden_states
         del original_hidden_states
 
-        can_use_cache = self.validate_can_use_cache_function(
-            get_can_use_cache(
-                first_hidden_states_residual,
-                threshold=self.residual_diff_threshold,
-            )
+        can_use_cache = get_can_use_cache(
+            first_hidden_states_residual,
+            threshold=self.residual_diff_threshold,
         )
+        if self.validate_can_use_cache_function is not None:
+            can_use_cache = self.validate_can_use_cache_function(can_use_cache)
 
         torch._dynamo.graph_break()
         if can_use_cache:

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -122,6 +122,7 @@ class CachedTransformerBlocks(torch.nn.Module):
         single_transformer_blocks=None,
         *,
         residual_diff_threshold,
+        validate_can_use_cache_function,
         return_hidden_states_first=True,
         accept_hidden_states_first=True,
         cat_hidden_states_first=False,
@@ -132,6 +133,7 @@ class CachedTransformerBlocks(torch.nn.Module):
         self.transformer_blocks = transformer_blocks
         self.single_transformer_blocks = single_transformer_blocks
         self.residual_diff_threshold = residual_diff_threshold
+        self.validate_can_use_cache_function=validate_can_use_cache_function
         self.return_hidden_states_first = return_hidden_states_first
         self.accept_hidden_states_first = accept_hidden_states_first
         self.cat_hidden_states_first = cat_hidden_states_first
@@ -209,9 +211,11 @@ class CachedTransformerBlocks(torch.nn.Module):
         first_hidden_states_residual = hidden_states - original_hidden_states
         del original_hidden_states
 
-        can_use_cache = get_can_use_cache(
-            first_hidden_states_residual,
-            threshold=self.residual_diff_threshold,
+        can_use_cache = self.validate_can_use_cache_function(
+            get_can_use_cache(
+                first_hidden_states_residual,
+                threshold=self.residual_diff_threshold,
+            )
         )
 
         torch._dynamo.graph_break()


### PR DESCRIPTION
This pull adds an advanced FBCache node:

![image](https://github.com/user-attachments/assets/4c12cb47-09ee-449a-b91c-102bbead0901)

The node allows scheduling the FBCache effect start/end percentages and also allows limiting how many times the cache can be applied consecutively. Setting it to 1 or 2 is still a noticeable speed increase while limiting the negative effect on quality.

I also fixed an issue where it was possible to end up with an invalid cached residual in same cases sampling with FBCache and then switching to a different latent size (such as in a highres fix type workflow).

Only tested with Flux, though I believe these changes shouldn't break other models.