### PR TITLE
Fix broken internal link to 'Enhanced torch.compile' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can find demo workflows in the `workflows` folder.
 
 [SDXL with First Block Cache](./workflows/sdxl.json)
 
-**NOTE**: The compilation node requires your computation to meet some software and hardware requirements, please refer to the [Enhanced `torch.compile`](Enhanced `torch.compile`) section for more information.
+**NOTE**: The compilation node requires your computation to meet some software and hardware requirements, please refer to the [Enhanced `torch.compile`](#enhanced-torchcompile) section for more information.
 
 ## Dynamic Caching ([First Block Cache](https://github.com/chengzeyi/ParaAttention?tab=readme-ov-file#first-block-cache-our-dynamic-caching))
 


### PR DESCRIPTION
Hello!

This PR fixes a broken link in the documentation that previously pointed to [Enhanced `torch.compile`](Enhanced `torch.compile`).

The link has been updated to `#enhanced-torchcompile`, ensuring correct navigation to the intended section within the page.

Let me know if you have any questions or require further adjustments!