### PR TITLE
Clean up some of the FBCache exception handling and state tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Some configurations for different models that you can try:
 | `sd3.5_large_fp8_scaled.safetensors` | 30 | 0.12 |
 | `sd_xl_base_1.0.safetensors` | 25 | 0.2 |
 
+**NOTE**: SDXL First Block Cache is incompatible with the [FreeU Advanced](https://github.com/WASasquatch/FreeU_Advanced) node pack and will not function properly if it is installed and enabled.
+
 See [Apply First Block Cache on FLUX.1-dev](https://github.com/chengzeyi/ParaAttention/blob/main/doc/fastest_flux.md#apply-first-block-cache-on-flux1-dev) for more information and detailed comparison on quality and speed.
 
 ![Usage of First Block Cache](./assets/usage_fbcache.png)

--- a/fbcache_nodes.py
+++ b/fbcache_nodes.py
@@ -115,8 +115,38 @@ class ApplyFBCacheOnModel:
             validate_use_cache = None
 
         prev_timestep = None
+        prev_input_state = None
         current_timestep = None
         consecutive_cache_hits = 0
+
+        def reset_cache_state():
+            # Resets the cache state and hits/time tracking variables.
+            nonlocal prev_input_state, prev_timestep, consecutive_cache_hits
+            prev_input_state = prev_timestep = None
+            consecutive_cache_hits = 0
+            first_block_cache.set_current_cache_context(
+                first_block_cache.create_cache_context())
+
+        def ensure_cache_state(model_input: torch.Tensor, timestep: float):
+            # Validates the current cache state and hits/time tracking variables
+            # and triggers a reset if necessary. Also updates current_timestep.
+            nonlocal current_timestep
+            input_state = (model_input.shape, model_input.dtype, model_input.device)
+            need_reset = (
+                prev_timestep is None or
+                prev_input_state != input_state or
+                first_block_cache.get_current_cache_context() is None or
+                timestep >= prev_timestep
+            )
+            if need_reset:
+                reset_cache_state()
+            current_timestep = timestep
+
+        def update_cache_state(model_input: torch.Tensor, timestep: float):
+            # Updates the previous timestep and input state validation variables.
+            nonlocal prev_timestep, prev_input_state
+            prev_timestep = timestep
+            prev_input_state = (model_input.shape, model_input.dtype, model_input.device)
 
         model = model.clone()
         diffusion_model = model.get_model_object(object_to_patch)
@@ -131,35 +161,27 @@ class ApplyFBCacheOnModel:
                 raise ValueError(
                     f"Unsupported model {diffusion_model.__class__.__name__}")
 
-            patch_foward = create_patch_function(
+            patch_forward = create_patch_function(
                 diffusion_model,
                 residual_diff_threshold=residual_diff_threshold,
                 validate_can_use_cache_function=validate_use_cache,
             )
 
             def model_unet_function_wrapper(model_function, kwargs):
-                nonlocal prev_timestep, current_timestep, consecutive_cache_hits
-
                 try:
                     input = kwargs["input"]
                     timestep = kwargs["timestep"]
                     c = kwargs["c"]
-                    current_timestep = t = timestep[0].item()
+                    t = timestep[0].item()
 
-                    if prev_timestep is None or t >= prev_timestep:
-                        prev_timestep = t
-                        consecutive_cache_hits = 0
-                        first_block_cache.set_current_cache_context(
-                            first_block_cache.create_cache_context())
+                    ensure_cache_state(input, t)
 
-                    if first_block_cache.get_current_cache_context() is None:
-                        first_block_cache.set_current_cache_context(
-                            first_block_cache.create_cache_context())
-
-                    with patch_foward():
-                        return model_function(input, timestep, **c)
-                except model_management.InterruptProcessingException as exc:
-                    prev_timestep = None
+                    with patch_forward():
+                        result = model_function(input, timestep, **c)
+                        update_cache_state(input, t)
+                        return result
+                except Exception as exc:
+                    reset_cache_state()
                     raise exc from None
         else:
             is_non_native_ltxv = False
@@ -224,23 +246,13 @@ class ApplyFBCacheOnModel:
             dummy_single_transformer_blocks = torch.nn.ModuleList()
 
             def model_unet_function_wrapper(model_function, kwargs):
-                nonlocal prev_timestep, current_timestep, consecutive_cache_hits
-
                 try:
                     input = kwargs["input"]
                     timestep = kwargs["timestep"]
                     c = kwargs["c"]
-                    current_timestep = t = timestep[0].item()
+                    t = timestep[0].item()
 
-                    if prev_timestep is None or t >= prev_timestep:
-                        prev_timestep = t
-                        consecutive_cache_hits = 0
-                        first_block_cache.set_current_cache_context(
-                            first_block_cache.create_cache_context())
-
-                    if first_block_cache.get_current_cache_context() is None:
-                        first_block_cache.set_current_cache_context(
-                            first_block_cache.create_cache_context())
+                    ensure_cache_state(input, t)
 
                     with unittest.mock.patch.object(
                             diffusion_model,
@@ -252,9 +264,11 @@ class ApplyFBCacheOnModel:
                             dummy_single_transformer_blocks,
                     ) if single_blocks_name is not None else contextlib.nullcontext(
                     ):
-                        return model_function(input, timestep, **c)
-                except model_management.InterruptProcessingException as exc:
-                    prev_timestep = None
+                        result = model_function(input, timestep, **c)
+                        update_cache_state(input, t)
+                        return result
+                except Exception as exc:
+                    reset_cache_state()
                     raise exc from None
 
         model.set_model_unet_function_wrapper(model_unet_function_wrapper)

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -386,12 +386,10 @@ def create_patch_unet_model__forward(model,
     from comfy.ldm.modules.diffusionmodules.openaimodel import timestep_embedding, forward_timestep_embed, apply_control
 
     def call_remaining_blocks(self, transformer_options, control,
-                              transformer_patches, hs, h, *args, **kwargs):
+                              transformer_patches, hs, h, *args, start_block=2, **kwargs):
         original_hidden_states = h
 
-        for id, module in enumerate(self.input_blocks):
-            if id < 2:
-                continue
+        for id, module in enumerate(self.input_blocks[start_block:], start=start_block):
             transformer_options["block"] = ("input", id)
             h = forward_timestep_embed(module, h, *args, **kwargs)
             h = apply_control(h, control, 'input')
@@ -478,9 +476,7 @@ def create_patch_unet_model__forward(model,
         can_use_cache = False
 
         h = x
-        for id, module in enumerate(self.input_blocks):
-            if id >= 2:
-                break
+        for id, module in enumerate(self.input_blocks[:2]):
             transformer_options["block"] = ("input", id)
             if id == 1:
                 original_h = h

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -386,10 +386,12 @@ def create_patch_unet_model__forward(model,
     from comfy.ldm.modules.diffusionmodules.openaimodel import timestep_embedding, forward_timestep_embed, apply_control
 
     def call_remaining_blocks(self, transformer_options, control,
-                              transformer_patches, hs, h, *args, start_block=2, **kwargs):
+                              transformer_patches, hs, h, *args, **kwargs):
         original_hidden_states = h
 
-        for id, module in enumerate(self.input_blocks[start_block:], start=start_block):
+        for id, module in enumerate(self.input_blocks):
+            if id < 2:
+                continue
             transformer_options["block"] = ("input", id)
             h = forward_timestep_embed(module, h, *args, **kwargs)
             h = apply_control(h, control, 'input')
@@ -476,7 +478,9 @@ def create_patch_unet_model__forward(model,
         can_use_cache = False
 
         h = x
-        for id, module in enumerate(self.input_blocks[:2]):
+        for id, module in enumerate(self.input_blocks):
+            if id >= 2:
+                break
             transformer_options["block"] = ("input", id)
             if id == 1:
                 original_h = h


### PR DESCRIPTION
This pull refactors the FBCache state tracking/validation logic to be (I hope) more robust and easier to maintain. 

It also checks that the model input shape, device and dtype are the same as what was cached and triggers a reset if not. I think there was a problem in the current state tracking (unless I misunderstood something) because `prev_timestep` was only getting updated if there was an exception.

I also changed the exception handling in the FBCache node to reset the cache if it encounters any exception rather than just the ComfyUI workflow interrupted one. My fault for implementing that incorrectly, obviously we'd want to reset the cache for any exception.

I also found that the FreeU Advanced nodes prevent FBCache from working with SDXL, probably because it monkeypatches ComfyUI's forward and timestep embed functions. I believe this would only affect UNet models, so it shouldn't matter for models like Flux, video, SD35, etc.

I tested these changes with SDXL and Flux.

Please let me know if you'd like any changes.