### PR TITLE
Handle multiple model calls on the same timestep

### DIFF
--- a/fbcache_nodes.py
+++ b/fbcache_nodes.py
@@ -129,21 +129,35 @@ class ApplyFBCacheOnModel:
 
         def ensure_cache_state(model_input: torch.Tensor, timestep: float):
             # Validates the current cache state and hits/time tracking variables
-            # and triggers a reset if necessary. Also updates current_timestep.
+            # and triggers a reset if necessary. Also updates current_timestep and
+            # maintains the cache context sequence number.
             nonlocal current_timestep
-            input_state = (model_input.shape[1:], model_input.dtype, model_input.device)
+            input_state = (model_input.shape, model_input.dtype, model_input.device)
             cache_context = first_block_cache.get_current_cache_context()
+            # We reset when:
             need_reset = (
+                # The previous timestep or input state is not set
                 prev_timestep is None or
+                prev_input_state is None or
+                # Or dtype/device have changed
                 prev_input_state[1:] != input_state[1:] or
+                # Or the input state after the batch dimension has changed
+                prev_input_state[0][1:] != input_state[0][1:] or
+                # Or there is no cache context (in this case reset is just making a context)
                 cache_context is None or
+                # Or the current timestep is higher than the previous one
                 timestep > prev_timestep
             )
             if need_reset:
                 reset_cache_state()
             elif timestep == prev_timestep:
+                # When the current timestep is the same as the previous, we assume ComfyUI has split up
+                # the model evaluation into multiple chunks. In this case, we increment the sequence number.
+                # Note: No need to check if cache_context is None for these branches as need_reset would be True
+                #       if so.
                 cache_context.sequence_num += 1
             elif timestep < prev_timestep:
+                # When the timestep is less than the previous one, we can reset the context sequence number
                 cache_context.sequence_num = 0
             current_timestep = timestep
 

--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -160,11 +160,12 @@ def get_can_use_cache(first_hidden_states_residual,
         only_shape=cache_context.sequence_num > 0,
     )
     if cache_context.sequence_num > 0:
-        return can_use_cache and cache_context.use_cache
-    if validation_function is not None:
-        can_use_cache = validation_function(can_use_cache)
-    cache_context.use_cache = can_use_cache
-    return can_use_cache
+        cache_context.use_cache &= can_use_cache
+    else:
+        if validation_function is not None:
+            can_use_cache = validation_function(can_use_cache)
+        cache_context.use_cache = can_use_cache
+    return cache_context.use_cache
 
 
 class CachedTransformerBlocks(torch.nn.Module):


### PR DESCRIPTION
This pull probably should be considered WIP and discussed before merging (though I think it's better than the current behavior as is).

As mentioned in #57, ComfyUI will split up the cond and uncond generation into separate model calls if it doesn't think it has enough memory to run everything together.

The two chunks will have the same sigma. Consider a hypothetical scenario where the first two sigmas are `1.0, 0.8`:

1. The cond batch runs at sigma 1.0
2. The uncond batch runs at sigma 1.0 - the cache gets reset first and the residual from uncond is cached.
3. Next step cond batch runs at sigma 0.8, the similarity check is now between the previous step uncond and the current step cond. If the similarity test succeeds, FBCache will use the residual from uncond here which will lead to bizarre results.

This pull changes the FBCache context handling to use a sequence number for the number of model evaluations at the current timestep and tracks the residual separately for each. As a side benefit, model patches like PAG, SAG, etc should work and be subject to caching when applicable. (PAG/SAG will do a separate model call on cond or uncond, if you're not familiar with the behavior.)

There's an edge case in FBCache without this pull: If the user is doing split sampling and samples say to sigma 0.5, then starts sampling from sigma 0.4 in a different sampler then FBCache will not know to reset the cache.

With this pull, I believe that edge case is expanded to include the case where the second sampler starts on the _same_ sigma that the previous one ended on. Unfortunately, I don't think there's any way to resolve these edge cases with the current model patch version of FBCache. A different approach would be to use a sampler wrapper instead, that way FBCache could know when sampling starts. Not sure if you'd be interested in adding a sampler wrapper version (or possibly replacing the existing model patch variation). Example of how using a sampler wrapper for a model patch looks: https://gist.github.com/blepping/50103df387945b3fb2691a46812b4a64

Should resolve #57

***

https://github.com/chengzeyi/Comfy-WaveSpeed/pull/83/commits/3c0d69068bce28b484a50e84b4e9e3e577ca518c adds timestep unified threshold checking. Or in other words, whatever decision we make about caching on the first model evaluation at a timestep we also use for subsequent ones to avoid using FBCache for cond but not uncond, etc.

Maximum consecutive cache caching didn't work in that case: since the validation function would be called multiple times on a timestep, it would think multiple consecutive cache hit occurred. It is probably possible to deal with this issue a different way but I think the approach I took here is _probably_ the simplest and least error-prone.

In the normal case where ComfyUI doesn't split up a batch, the behavior should be the same as before.