### PR TITLE
fix: Remove unsupported `modulation_dims_img` and `modulation_dims_txt` kwargs causing TypeError

### DIFF
--- a/first_block_cache.py
+++ b/first_block_cache.py
@@ -258,6 +258,8 @@ class CachedTransformerBlocks(torch.nn.Module):
                     [encoder_hidden_states, hidden_states],
                     dim=1)
                 for block in self.single_transformer_blocks:
+                    kwargs.pop("modulation_dims_img", None)
+                    kwargs.pop("modulation_dims_txt", None)
                     hidden_states = block(hidden_states, *args, **kwargs)
                 hidden_states = hidden_states[:,
                                               encoder_hidden_states.shape[1]:]
@@ -367,6 +369,8 @@ class CachedTransformerBlocks(torch.nn.Module):
                                       [encoder_hidden_states, hidden_states],
                                       dim=1)
             for block in self.single_transformer_blocks:
+                kwargs.pop("modulation_dims_img", None)
+                kwargs.pop("modulation_dims_txt", None)
                 hidden_states = block(hidden_states, *args, **kwargs)
             if self.cat_hidden_states_first:
                 hidden_states, encoder_hidden_states = hidden_states.split(


### PR DESCRIPTION
This PR fixes a compatibility issue with ComfyUI v0.3.26, resolving a runtime `TypeError` caused by unexpected keyword arguments `modulation_dims_img` and `modulation_dims_txt` passed to `SingleStreamBlock.forward()`.

### Problem
- The current implementation passes unsupported kwargs (`modulation_dims_img`, `modulation_dims_txt`) into transformer blocks, which triggers an error in ComfyUI 0.3.26.

### Solution
- Explicitly remove these kwargs from `**kwargs` before calling transformer blocks.

### Impact
- Ensures compatibility with ComfyUI v0.3.26.
- Prevents runtime exceptions allowing stable execution.

### Testing
- Verified locally by running workflows previously affected by the error.